### PR TITLE
Remove static allTests var

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the swift-libp2p open source project

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.5
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the swift-libp2p open source project

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.8
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the swift-libp2p open source project

--- a/Tests/Base2Tests/Base2Tests.swift
+++ b/Tests/Base2Tests/Base2Tests.swift
@@ -75,10 +75,4 @@ final class Base2Tests: XCTestCase {
 
         XCTAssertEqual(testData, decoded)
     }
-
-    static var allTests = [
-        ("testBase2", testBase2),
-        ("testBase2EncodingStringExtensions", testBase2EncodingStringExtensions),
-        ("testBase2EncodingDataExtensions", testBase2EncodingDataExtensions),
-    ]
 }

--- a/Tests/Base32Tests/Base32Tests.swift
+++ b/Tests/Base32Tests/Base32Tests.swift
@@ -313,20 +313,4 @@ final class Base32Tests: XCTestCase {
         //XCTAssertEqual(Base32.encode("hello world".data(using: .ascii)!, variant: .z), "D1IMOR3F41RMUSJCCG======"                )
         //XCTAssertEqual(Base32.encode("Decentralize everything!!".data(using: .ascii)!, variant: .z), "8HIM6PBEEHP62R39F9II0PBMCLP7IT38D5N6E891")
     }
-
-    static var allTests = [
-        ("testEncodeStandard", testEncodeStandard),
-        ("testDecodeStandard", testDecodeStandard),
-        ("testEncodeStandardLowercaseWithPadding", testEncodeStandardLowercaseWithPadding),
-        ("testEncodeStandardUppercaseWithoutPadding", testEncodeStandardUppercaseWithoutPadding),
-        ("testEncodeStandardLowercaseWithoutPadding", testEncodeStandardLowercaseWithoutPadding),
-
-        ("testEncodeHex", testEncodeHex),
-        ("testDecodeHex", testDecodeHex),
-        ("testEncodeHexLowercaseWithPadding", testEncodeHexLowercaseWithPadding),
-        ("testEncodeHexUppercaseWithoutPadding", testEncodeHexUppercaseWithoutPadding),
-        ("testEncodeHexLowercaseWithoutPadding", testEncodeHexLowercaseWithoutPadding),
-
-        ("testZ", testZ),
-    ]
 }

--- a/Tests/Base8Tests/Base8Tests.swift
+++ b/Tests/Base8Tests/Base8Tests.swift
@@ -72,12 +72,4 @@ final class Base8Tests: XCTestCase {
         XCTAssertEqual(Base8.encode("yes mani !", options: .pad(true)), "362625631006654133464440102=====")
         XCTAssertEqual(Base8.encode("yes mani !", options: .pad(false)), "362625631006654133464440102")
     }
-
-    static var allTests = [
-        ("testEncode", testEncode),
-        ("testDecode", testDecode),
-        ("testLeadingZero", testLeadingZero),
-        ("testTwoLeadingZeros", testTwoLeadingZeros),
-        ("testEncodeWithOptions", testEncodeWithOptions),
-    ]
 }

--- a/Tests/BaseXTests/BaseXTests.swift
+++ b/Tests/BaseXTests/BaseXTests.swift
@@ -256,28 +256,4 @@ final class BaseXTests: XCTestCase {
             "let base58FlickrDecoded:String = try BaseX.decode(\"\(base58FlickrEncoded)\", as: .base58Flickr) // -> \(base58FlickrDecoded)"
         )
     }
-
-    static var allTests = [
-        ("testBase10", testBase10),
-        ("testBase16Lower", testBase16Lower),
-        ("testBase16Upper", testBase16Upper),
-        ("testBase36Lower", testBase36Lower),
-        ("testBase36Upper", testBase36Upper),
-        ("testBase58BTC", testBase58BTC),
-        ("testBase58Flickr", testBase58Flickr),
-        ("testBase10LeadingZero", testBase10LeadingZero),
-        ("testBase16LowerLeadingZero", testBase16LowerLeadingZero),
-        ("testBase16UpperLeadingZero", testBase16UpperLeadingZero),
-        ("testBase36LowerLeadingZero", testBase36LowerLeadingZero),
-        ("testBase36UpperLeadingZero", testBase36UpperLeadingZero),
-        ("testBase58BTCLeadingZero", testBase58BTCLeadingZero),
-        ("testBase58FlickrLeadingZero", testBase58FlickrLeadingZero),
-        ("testBase10TwoLeadingZeros", testBase10TwoLeadingZeros),
-        ("testBase16LowerTwoLeadingZeros", testBase16LowerTwoLeadingZeros),
-        ("testBase16UpperTwoLeadingZeros", testBase16UpperTwoLeadingZeros),
-        ("testBase36LowerTwoLeadingZeros", testBase36LowerTwoLeadingZeros),
-        ("testBase36UpperTwoLeadingZeros", testBase36UpperTwoLeadingZeros),
-        ("testBase58BTCTwoLeadingZeros", testBase58BTCTwoLeadingZeros),
-        ("testBase58FlickrTwoLeadingZeros", testBase58FlickrTwoLeadingZeros),
-    ]
 }


### PR DESCRIPTION
### What
- Removes the static allTests var from our XCTestCase classes.

### Why
- SPM Tools 5.5+ auto discovers tests so the allTests var is no longer needed.